### PR TITLE
Adding CODEOWNERS updating README.md and remove gorelease run from pr-s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
 #      - main
     tags:
       - v*
-  pull_request:
   workflow_dispatch:
 jobs:
   build:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+*   @henderiw @steiler @hansthienpondt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+![Kubenet logo](https://learn.kubenet.dev/assets/logos/Kubenet-logo-transparent-withname-100x123.png)
+
+[![Discord](https://img.shields.io/discord/860500297297821756?style=flat-square&label=discord&logo=discord&color=00c9ff&labelColor=bec8d2)](https://discord.gg/fH35bmcTU9)
+
 # kubenetctl
 
-CLI tool to help execute the kubenet exercises.
+CLI tool to help execute the [Kubenet](https://learn.kubenet.dev/) exercises.
+
+More information about Kubenet in [learn.kubenet.dev](https://learn.kubenet.dev/).
+
+## Contributions
+
+Any contributions are welcome in the form of GitHub [issues](https://github.com/kubenet-dev/kubenetctl/issues),
+[pull requests](https://github.com/kubenet-dev/kubenetctl/pulls) or discussion on
+[Discord](https://discord.gg/fH35bmcTU9).
+
+## License and governance
+
+Code in the Kubenet repositories licensed with Apache License 2.0. At the moment the project is governed by the benevolent dictatorship of @henderiw @steiler @karimra and @hansthienpondt . On the long run we plan to move to a meritocracy based governance model.


### PR DESCRIPTION
README extended with more information about Kubenet, governance, licensing and contributions.

Gorelease run is not needed for every pr-run, therefore I've removed that trigger. 